### PR TITLE
feat(ego-token-utils): defines API to support token verification

### DIFF
--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,23 +1,4 @@
-import utils from '../src/ego-token-utils'
-
-const {
-  isValidJwt,
-  getReadableProgramScopes,
-  isDccMember,
-  canReadProgram,
-  canWriteProgram,
-  isProgramAdmin,
-  isPermission,
-  isRdpcMember,
-  parseScope,
-  serializeScope,
-  canReadSomeProgram,
-  decodeToken,
-  getReadableProgramShortNames,
-  getWriteableProgramScopes,
-  canWriteSomeProgram,
-  getWriteableProgramShortNames
-} = utils
+import createValidator from '../src/ego-token-utils'
 
 /** has the following scopes:
  * "PROGRAMDATA-PACA-AU.WRITE"
@@ -43,45 +24,49 @@ const EXPIRED_TOKEN =
 
 const BOGUS_PROGRAM_ID = 'BOGUS_PROGRAM'
 
+const PUBLIC_KEY = ''
+
+const validator = createValidator(PUBLIC_KEY)
+
 describe('isRdpcMember', () => {
   it('should invalidate all non RDPC tokens', () => {
     ;[DATA_SUBMITTER, PROGRAM_ADMIN, DCC_USER].forEach(token => {
-      expect(isRdpcMember(token)).toBe(false)
+      expect(validator.isRdpcMember(token)).toBe(false)
     })
   })
   it('should return false if failed', () => {
-    expect(isRdpcMember('ssdfg')).toBe(false)
+    expect(validator.isRdpcMember('ssdfg')).toBe(false)
   })
 })
 
 describe('parseScope', () => {
   it('should parse valid scopes correctly', () => {
-    expect(parseScope('PROGRAM-WP-CPMP-US.READ')).toEqual({
+    expect(validator.parseScope('PROGRAM-WP-CPMP-US.READ')).toEqual({
       policy: 'PROGRAM-WP-CPMP-US',
       permission: 'READ'
     })
-    expect(parseScope('PROGRAM-WP-CPMP-US.WRITE')).toEqual({
+    expect(validator.parseScope('PROGRAM-WP-CPMP-US.WRITE')).toEqual({
       policy: 'PROGRAM-WP-CPMP-US',
       permission: 'WRITE'
     })
-    expect(parseScope('PROGRAM-WP-CPMP-US.ADMIN')).toEqual({
+    expect(validator.parseScope('PROGRAM-WP-CPMP-US.ADMIN')).toEqual({
       policy: 'PROGRAM-WP-CPMP-US',
       permission: 'ADMIN'
     })
-    expect(parseScope('PROGRAM-WP-CPMP-US.DENY')).toEqual({
+    expect(validator.parseScope('PROGRAM-WP-CPMP-US.DENY')).toEqual({
       policy: 'PROGRAM-WP-CPMP-US',
       permission: 'DENY'
     })
   })
   it('should throw error ', () => {
-    expect(() => parseScope('PROGRAM-WP-CPMP-US.sdfgsdfg')).toThrow()
+    expect(() => validator.parseScope('PROGRAM-WP-CPMP-US.sdfgsdfg')).toThrow()
   })
 })
 
 describe('serializeScope', () => {
   it('should serialize properly', () => {
     expect(
-      serializeScope({
+      validator.serializeScope({
         policy: 'PROGRAM-WP-CPMP-US',
         permission: 'DENY'
       })
@@ -92,143 +77,149 @@ describe('serializeScope', () => {
 describe('isPermission', () => {
   it('should validates all permissions', () => {
     ;['READ', 'WRITE', 'ADMIN', 'DENY'].forEach(str => {
-      expect(isPermission(str)).toBe(true)
+      expect(validator.isPermission(str)).toBe(true)
     })
   })
   it('should invalidate non permission', () => {
     ;['', undefined, 1, null].forEach(str => {
-      expect(isPermission(str)).toBe(false)
+      expect(validator.isPermission(str)).toBe(false)
     })
   })
 })
 
 describe('isValidJwt', () => {
   it('should return false if undefined', () => {
-    expect(isValidJwt()).toBe(false)
+    expect(validator.isValidJwt()).toBe(false)
   })
   it('should return false if failed', () => {
-    expect(isValidJwt('sfgsdfg')).toBe(false)
+    expect(validator.isValidJwt('sfgsdfg')).toBe(false)
   })
   it('should return true for valid jwt', () => {
     ;[DATA_SUBMITTER, PROGRAM_ADMIN, DCC_USER].forEach(token => {
-      expect(isValidJwt(token)).toBe(true)
+      expect(validator.isValidJwt(token)).toBe(true)
     })
   })
   it('should return false for expired token', () => {
-    expect(isValidJwt(EXPIRED_TOKEN)).toBe(false)
+    expect(validator.isValidJwt(EXPIRED_TOKEN)).toBe(false)
   })
 })
 
 describe('getReadableProgramScopes', () => {
   it('should return authorized program scopes', () => {
-    expect(getReadableProgramScopes(DATA_SUBMITTER)).toEqual([])
-    expect(getReadableProgramScopes(PROGRAM_ADMIN)).toEqual([
+    expect(validator.getReadableProgramScopes(DATA_SUBMITTER)).toEqual([])
+    expect(validator.getReadableProgramScopes(PROGRAM_ADMIN)).toEqual([
       { policy: 'PROGRAM-PACA-AU', permission: 'WRITE' }
     ])
-    expect(getReadableProgramScopes(DCC_USER)).toEqual([])
+    expect(validator.getReadableProgramScopes(DCC_USER)).toEqual([])
   })
 })
 
 describe('getWriteableProgramScopes', () => {
   it('should return authorized program scopes', () => {
-    expect(getWriteableProgramScopes(DATA_SUBMITTER)).toEqual([])
-    expect(getWriteableProgramScopes(PROGRAM_ADMIN)).toEqual([
+    expect(validator.getWriteableProgramScopes(DATA_SUBMITTER)).toEqual([])
+    expect(validator.getWriteableProgramScopes(PROGRAM_ADMIN)).toEqual([
       { policy: 'PROGRAM-PACA-AU', permission: 'WRITE' }
     ])
-    expect(getWriteableProgramScopes(DCC_USER)).toEqual([])
+    expect(validator.getWriteableProgramScopes(DCC_USER)).toEqual([])
   })
 })
 
 describe('getReadableProgramShortNames', () => {
   it('should return authorized program names', () => {
-    expect(getReadableProgramShortNames(DATA_SUBMITTER)).toEqual([])
-    expect(getReadableProgramShortNames(PROGRAM_ADMIN)).toEqual(['PACA-AU'])
-    expect(getReadableProgramShortNames(DCC_USER)).toEqual([])
+    expect(validator.getReadableProgramShortNames(DATA_SUBMITTER)).toEqual([])
+    expect(validator.getReadableProgramShortNames(PROGRAM_ADMIN)).toEqual(['PACA-AU'])
+    expect(validator.getReadableProgramShortNames(DCC_USER)).toEqual([])
   })
 })
 
 describe('getWriteableProgramShortNames', () => {
   it('should return authorized program names', () => {
-    expect(getWriteableProgramShortNames(DATA_SUBMITTER)).toEqual([])
-    expect(getWriteableProgramShortNames(PROGRAM_ADMIN)).toEqual(['PACA-AU'])
-    expect(getWriteableProgramShortNames(DCC_USER)).toEqual([])
+    expect(validator.getWriteableProgramShortNames(DATA_SUBMITTER)).toEqual([])
+    expect(validator.getWriteableProgramShortNames(PROGRAM_ADMIN)).toEqual(['PACA-AU'])
+    expect(validator.getWriteableProgramShortNames(DCC_USER)).toEqual([])
   })
 })
 
 describe('isDccMember', () => {
   it('should validate DCC member as such', () => {
-    expect(isDccMember(DCC_USER)).toBe(true)
+    expect(validator.isDccMember(DCC_USER)).toBe(true)
   })
   it('should validate non DCC member as such', () => {
-    expect(isDccMember(DATA_SUBMITTER)).toBe(false)
+    expect(validator.isDccMember(DATA_SUBMITTER)).toBe(false)
   })
   it('should return false if fail', () => {
-    expect(isDccMember('asdfsdf')).toBe(false)
+    expect(validator.isDccMember('asdfsdf')).toBe(false)
   })
 })
 
 describe('canReadProgram', () => {
   it('should validate read access', () => {
-    expect(canReadProgram({ egoJwt: PROGRAM_ADMIN, programId: 'PACA-AU' })).toBe(true)
+    expect(validator.canReadProgram({ egoJwt: PROGRAM_ADMIN, programId: 'PACA-AU' })).toBe(true)
   })
   it('should handle "" for programId correctly', () => {
-    expect(canReadProgram({ egoJwt: PROGRAM_ADMIN, programId: '' })).toBe(false)
+    expect(validator.canReadProgram({ egoJwt: PROGRAM_ADMIN, programId: '' })).toBe(false)
   })
   it('should invalidate read access', () => {
-    expect(canReadProgram({ egoJwt: PROGRAM_ADMIN, programId: BOGUS_PROGRAM_ID })).toBe(false)
+    expect(validator.canReadProgram({ egoJwt: PROGRAM_ADMIN, programId: BOGUS_PROGRAM_ID })).toBe(
+      false
+    )
   })
   it('should give dcc members access', () => {
-    expect(canReadProgram({ egoJwt: DCC_USER, programId: '' })).toBe(true)
+    expect(validator.canReadProgram({ egoJwt: DCC_USER, programId: '' })).toBe(true)
   })
 })
 
 describe('canWriteProgram', () => {
   it('should validate write access', () => {
-    expect(canWriteProgram({ egoJwt: PROGRAM_ADMIN, programId: 'PACA-AU' })).toBe(true)
+    expect(validator.canWriteProgram({ egoJwt: PROGRAM_ADMIN, programId: 'PACA-AU' })).toBe(true)
   })
   it('should invalidate write access', () => {
-    expect(canWriteProgram({ egoJwt: PROGRAM_ADMIN, programId: BOGUS_PROGRAM_ID })).toBe(false)
+    expect(validator.canWriteProgram({ egoJwt: PROGRAM_ADMIN, programId: BOGUS_PROGRAM_ID })).toBe(
+      false
+    )
   })
   it('should handle "" for programId correctly', () => {
-    expect(canWriteProgram({ egoJwt: PROGRAM_ADMIN, programId: '' })).toBe(false)
+    expect(validator.canWriteProgram({ egoJwt: PROGRAM_ADMIN, programId: '' })).toBe(false)
   })
   it('should invalidate read only access', () => {
-    expect(canWriteProgram({ egoJwt: DATA_SUBMITTER, programId: 'WP-CPMP-US' })).toBe(false)
+    expect(validator.canWriteProgram({ egoJwt: DATA_SUBMITTER, programId: 'WP-CPMP-US' })).toBe(
+      false
+    )
   })
   it('should give dcc members access', () => {
-    expect(canReadProgram({ egoJwt: DCC_USER, programId: '' })).toBe(true)
+    expect(validator.canReadProgram({ egoJwt: DCC_USER, programId: '' })).toBe(true)
   })
 })
 
 describe('isProgramAdmin', () => {
   it('should validate admin access', () => {
-    expect(isProgramAdmin({ egoJwt: PROGRAM_ADMIN, programId: 'PACA-AU' })).toBe(true)
+    expect(validator.isProgramAdmin({ egoJwt: PROGRAM_ADMIN, programId: 'PACA-AU' })).toBe(true)
   })
   it('should invalidate read only access', () => {
-    expect(isProgramAdmin({ egoJwt: DATA_SUBMITTER, programId: 'PACA-AU' })).toBe(false)
+    expect(validator.isProgramAdmin({ egoJwt: DATA_SUBMITTER, programId: 'PACA-AU' })).toBe(false)
   })
 })
 
 describe('canReadSomeProgram', () => {
   it('should return true for dcc members', () => {
-    expect(canReadSomeProgram(DCC_USER)).toBe(true)
+    expect(validator.canReadSomeProgram(DCC_USER)).toBe(true)
   })
   it('should return true for program admin', () => {
-    expect(canReadSomeProgram(PROGRAM_ADMIN)).toBe(true)
+    expect(validator.canReadSomeProgram(PROGRAM_ADMIN)).toBe(true)
   })
   it('should return false for data submitters with no program access', () => {
-    expect(canReadSomeProgram(DATA_SUBMITTER)).toBe(false)
+    expect(validator.canReadSomeProgram(DATA_SUBMITTER)).toBe(false)
   })
 })
 
 describe('canWriteSomeProgram', () => {
   it('should return true for dcc members', () => {
-    expect(canWriteSomeProgram(DCC_USER)).toBe(true)
+    expect(validator.canWriteSomeProgram(DCC_USER)).toBe(true)
   })
   it('should return true for program admin', () => {
-    expect(canWriteSomeProgram(PROGRAM_ADMIN)).toBe(true)
+    expect(validator.canWriteSomeProgram(PROGRAM_ADMIN)).toBe(true)
   })
   it('should return false for data submitters with no program access', () => {
-    expect(canWriteSomeProgram(DATA_SUBMITTER)).toBe(false)
+    expect(validator.canWriteSomeProgram(DATA_SUBMITTER)).toBe(false)
   })
 })


### PR DESCRIPTION
BREAKING CHANGE: default exports a factory function that receives ego public key to use for token
verification