### PR TITLE
fix(rollup.config.js): fixes the build not bundling dependencies

### DIFF
--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -26,7 +26,9 @@ export default {
     // Compile TypeScript files
     typescript({ useTsconfigDeclarationDir: true }),
     // Allow bundling cjs modules (unlike webpack, rollup doesn't understand cjs)
-    commonjs(),
+    commonjs({
+      include: 'node_modules/**'
+    }),
     // Allow node_modules resolution, so you can use 'external' to control
     // which external modules to include in the bundle
     // https://github.com/rollup/rollup-plugin-node-resolve#usage


### PR DESCRIPTION
decode_jwt wasn't being pulled in properly in production build, this fixes that

BREAKING CHANGE: import can be done from package root