### PR TITLE
Verify JWT against Public Key

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1702,10 +1702,14 @@
       "integrity": "sha512-Q5hTcfdudEL2yOmluA1zaSyPbzWPmJ3XfSWeP3RyoYvS9hnje1ZyagrZOuQ6+1nQC1Gw+7gap3pLNL3xL6UBug==",
       "dev": true
     },
-    "@types/jwt-decode": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@types/jwt-decode/-/jwt-decode-2.2.1.tgz",
-      "integrity": "sha512-aWw2YTtAdT7CskFyxEX2K21/zSDStuf/ikI3yBqmwpwJF0pS+/IX5DWv+1UFffZIbruP6cnT9/LAJV1gFwAT1A=="
+    "@types/jsonwebtoken": {
+      "version": "8.3.3",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.3.3.tgz",
+      "integrity": "sha512-mofwpvFbm2AUxD5mg4iQPc2o/+ubM200R/L86kR17SeC99jM3gEnB9hy16ln3kZkxM5LnGpDJclxeUNEHhehng==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/lodash": {
       "version": "4.14.136",
@@ -2513,6 +2517,11 @@
       "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
       "integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc=",
       "dev": true
+    },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -3622,6 +3631,14 @@
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
+      }
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "electron-to-chromium": {
@@ -7134,6 +7151,35 @@
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
     },
+    "jsonwebtoken": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "requires": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
+      }
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -7146,10 +7192,24 @@
         "verror": "1.10.0"
       }
     },
-    "jwt-decode": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-2.2.0.tgz",
-      "integrity": "sha1-fYa9VmefWM5qhHBKZX3TkruoGnk="
+    "jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "requires": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "keyv": {
       "version": "3.1.0",
@@ -7458,23 +7518,46 @@
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+    },
     "lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
-      "dev": true
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
     },
     "lodash.isstring": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
-      "dev": true
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
     },
     "lodash.map": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
       "integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM=",
       "dev": true
+    },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "lodash.set": {
       "version": "4.3.2",
@@ -13277,8 +13360,7 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "safe-regex": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "@commitlint/cli": "^7.1.2",
     "@commitlint/config-conventional": "^7.1.2",
     "@types/jest": "^23.3.2",
+    "@types/jsonwebtoken": "^8.3.3",
     "@types/node": "^10.11.0",
     "colors": "^1.3.2",
     "commitizen": "^3.0.0",
@@ -119,7 +120,6 @@
     "typescript": "^3.0.3"
   },
   "dependencies": {
-    "@types/jwt-decode": "^2.2.1",
-    "jwt-decode": "^2.2.0"
+    "jsonwebtoken": "^8.5.1"
   }
 }

--- a/src/argoRoleChecks.ts
+++ b/src/argoRoleChecks.ts
@@ -1,0 +1,40 @@
+import { decodeToken, PERMISSIONS } from './common';
+
+export const DCC_PREFIX = 'PROGRAMSERVICE.WRITE';
+export const RDPC_PREFIX = 'RDPC-';
+
+/**
+ * check if a given jwt has dcc access
+ * @param egoJwt
+ */
+export const isDccMember = (egoPublicKey: string) => (egoJwt: string) => {
+  try {
+    const data = decodeToken(egoPublicKey)(egoJwt);
+    const permissions = data.context.scope;
+    return permissions.some(p => p.includes(DCC_PREFIX));
+  } catch (err) {
+    return false;
+  }
+};
+
+/**
+ * check if a given jwt has rdpc access
+ * @param egoJwt
+ */
+export const isRdpcMember = (egoPublicKey: string) => (egoJwt: string): boolean => {
+  try {
+    const data = decodeToken(egoPublicKey)(egoJwt);
+    const scopes = data.context.scope;
+    const rdpcPermissions = scopes.filter(p => {
+      const policy = p.split('.')[0];
+      return policy.indexOf(RDPC_PREFIX) === 0;
+    });
+    const isMember =
+      rdpcPermissions.some(p =>
+        [PERMISSIONS.READ, PERMISSIONS.WRITE, PERMISSIONS.ADMIN].includes(p.split('.')[1]),
+      ) && !rdpcPermissions.some(p => [PERMISSIONS.DENY].includes(p.split('.')[1]));
+    return isMember;
+  } catch (err) {
+    return false;
+  }
+};

--- a/src/common.ts
+++ b/src/common.ts
@@ -57,8 +57,7 @@ export const isPermission = (str: any): str is keyof typeof PERMISSIONS =>
  * wrapper for jwt-decode that provides static Ego typing
  * @param egoJwt
  */
-export const decodeToken = (egoPublicKey: string) => (egoJwt: string): EgoJwtData =>
-  jwtDecode(egoJwt);
+export const decodeToken = (egoJwt: string): EgoJwtData => jwtDecode(egoJwt);
 
 /**
  * check if a given jwt has dcc access
@@ -66,7 +65,7 @@ export const decodeToken = (egoPublicKey: string) => (egoJwt: string): EgoJwtDat
  */
 export const isDccMember = (egoPublicKey: string) => (egoJwt: string) => {
   try {
-    const data = decodeToken(egoPublicKey)(egoJwt);
+    const data = decodeToken(egoJwt);
     const permissions = data.context.scope;
     return permissions.some(p => p.includes(DCC_PREFIX));
   } catch (err) {

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,6 +1,4 @@
-import * as _jwtDecode from 'jwt-decode';
-
-const jwtDecode = _jwtDecode;
+import * as jwt from 'jsonwebtoken';
 
 export const PERMISSIONS: {
   READ: string;
@@ -13,10 +11,19 @@ export const PERMISSIONS: {
   ADMIN: 'ADMIN',
   DENY: 'DENY',
 };
-export const DCC_PREFIX = 'PROGRAMSERVICE.WRITE';
-export const RDPC_PREFIX = 'RDPC-';
 export const PROGRAM_PREFIX = 'PROGRAM-';
 export const PROGRAM_DATA_PREFIX = 'PROGRAMDATA-';
+
+export enum UserStatus {
+  APPROVED = 'APPROVED',
+  DISABLED = 'DISABLED',
+  PENDING = 'PENDING',
+  REJECTED = 'REJECTED',
+}
+export enum UserType {
+  ADMIN = 'ADMIN',
+  USER = 'USER',
+}
 
 export type EgoJwtData = {
   iat: number;
@@ -30,13 +37,13 @@ export type EgoJwtData = {
     user: {
       name: string;
       email: string;
-      status: 'APPROVED' | 'DISABLED' | 'PENDING' | 'REJECTED';
+      status: UserStatus;
       firstName: string;
       lastName: string;
       createdAt: number;
       lastLogin: number;
       preferredLanguage: string | undefined;
-      type: 'ADMIN' | 'USER';
+      type: UserType;
     };
   };
 };
@@ -54,22 +61,16 @@ export const isPermission = (str: any): str is keyof typeof PERMISSIONS =>
   Object.values(PERMISSIONS).includes(str);
 
 /**
- * wrapper for jwt-decode that provides static Ego typing
+ * Decode provided JWT to provide typed EgoJwtData object
+ * Missing values will be null in the provided object,
  * @param egoJwt
  */
-export const decodeToken = (egoJwt: string): EgoJwtData => jwtDecode(egoJwt);
-
-/**
- * check if a given jwt has dcc access
- * @param egoJwt
- */
-export const isDccMember = (egoPublicKey: string) => (egoJwt: string) => {
-  try {
-    const data = decodeToken(egoJwt);
-    const permissions = data.context.scope;
-    return permissions.some(p => p.includes(DCC_PREFIX));
-  } catch (err) {
-    return false;
+export const decodeToken = (egoPublicKey: string) => (egoJwt: string): EgoJwtData => {
+  const decoded = jwt.verify(egoJwt, egoPublicKey, { algorithms: ['RS256'] });
+  if (typeof decoded == 'string' || decoded === null) {
+    throw Error('Unexpected JWT Format');
+  } else {
+    return <EgoJwtData>decoded;
   }
 };
 

--- a/src/ego-token-utils.ts
+++ b/src/ego-token-utils.ts
@@ -30,7 +30,7 @@ const isValidJwt = (egoPublicKey: string) => (egoJwt?: string) => {
     if (!egoJwt) {
       return false;
     } else {
-      const { exp } = decodeToken(egoPublicKey)(egoJwt);
+      const { exp } = decodeToken(egoJwt);
       return exp * 1000 > Date.now();
     }
   } catch (err) {
@@ -44,7 +44,7 @@ const isValidJwt = (egoPublicKey: string) => (egoJwt?: string) => {
  */
 const isRdpcMember = (egoPublicKey: string) => (egoJwt: string) => {
   try {
-    const data = decodeToken(egoPublicKey)(egoJwt);
+    const data = decodeToken(egoJwt);
     const scopes = data.context.scope;
     const rdpcPermissions = scopes.filter(p => {
       const policy = p.split('.')[0];
@@ -80,7 +80,7 @@ const serializeScope = (scopeObj: PermissionScopeObj): string => {
 const getReadableProgramScopes = (egoPublicKey: string) => (
   egoJwt: string,
 ): PermissionScopeObj[] => {
-  const data = decodeToken(egoPublicKey)(egoJwt);
+  const data = decodeToken(egoJwt);
   const permissions = data.context.scope;
   const programPermissions = permissions.filter(p => {
     const policy = p.split('.')[0];
@@ -105,7 +105,7 @@ const getReadableProgramScopes = (egoPublicKey: string) => (
 const getWriteableProgramScopes = (egoPublicKey: string) => (
   egoJwt: string,
 ): PermissionScopeObj[] => {
-  const data = decodeToken(egoPublicKey)(egoJwt);
+  const data = decodeToken(egoJwt);
   const permissions = data.context.scope;
   const programPermissions = permissions.filter(p => {
     const policy = p.split('.')[0];
@@ -212,7 +212,7 @@ export default (egoPublicKey: string) => ({
   serializeScope: serializeScope,
   parseScope: parseScope,
   isPermission: isPermission,
-  decodeToken: decodeToken(egoPublicKey),
+  decodeToken: decodeToken,
   isValidJwt: isValidJwt(egoPublicKey),
   isDccMember: isDccMember(egoPublicKey),
   isRdpcMember: isRdpcMember(egoPublicKey),

--- a/src/programDataUtils.ts
+++ b/src/programDataUtils.ts
@@ -2,15 +2,16 @@ import {
   PermissionScopeObj,
   decodeToken,
   PROGRAM_DATA_PREFIX,
-  isDccMember,
   PERMISSIONS,
   parseScope,
 } from './common';
 
+import { isDccMember } from './argoRoleChecks';
+
 export const getReadableProgramDataScopes = (egoPublicKey: string) => (
   egoJwt: string,
 ): PermissionScopeObj[] => {
-  const data = decodeToken(egoJwt);
+  const data = decodeToken(egoPublicKey)(egoJwt);
   const permissions = data.context.scope;
   const programDataPermissions = permissions.filter(p => {
     const policy = p.split('.')[0];
@@ -33,7 +34,7 @@ export const getReadableProgramDataNames = (egoPublicKey: string) => (egoJwt: st
 export const getWritableProgramDataScopes = (egoPublicKey: string) => (
   egoJwt: string,
 ): PermissionScopeObj[] => {
-  const data = decodeToken(egoJwt);
+  const data = decodeToken(egoPublicKey)(egoJwt);
   const permissions = data.context.scope;
   const programDataPermissions = permissions.filter(p => {
     const policy = p.split('.')[0];

--- a/src/programDataUtils.ts
+++ b/src/programDataUtils.ts
@@ -10,7 +10,7 @@ import {
 export const getReadableProgramDataScopes = (egoPublicKey: string) => (
   egoJwt: string,
 ): PermissionScopeObj[] => {
-  const data = decodeToken(egoPublicKey)(egoJwt);
+  const data = decodeToken(egoJwt);
   const permissions = data.context.scope;
   const programDataPermissions = permissions.filter(p => {
     const policy = p.split('.')[0];
@@ -33,7 +33,7 @@ export const getReadableProgramDataNames = (egoPublicKey: string) => (egoJwt: st
 export const getWritableProgramDataScopes = (egoPublicKey: string) => (
   egoJwt: string,
 ): PermissionScopeObj[] => {
-  const data = decodeToken(egoPublicKey)(egoJwt);
+  const data = decodeToken(egoJwt);
   const permissions = data.context.scope;
   const programDataPermissions = permissions.filter(p => {
     const policy = p.split('.')[0];

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -25,9 +25,12 @@ const EXPIRED_TOKEN =
 
 const BOGUS_PROGRAM_ID = 'BOGUS_PROGRAM';
 
-const PUBLIC_KEY = '';
+const PUBLIC_KEY = `-----BEGIN PUBLIC KEY-----\r\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0lOqMuPLCVusc6szklNXQL1FHhSkEgR7An+8BllBqTsRHM4bRYosseGFCbYPn8r8FsWuMDtxp0CwTyMQR2PCbJ740DdpbE1KC6jAfZxqcBete7gP0tooJtbvnA6X4vNpG4ukhtUoN9DzNOO0eqMU0Rgyy5HjERdYEWkwTNB30i9I+nHFOSj4MGLBSxNlnuo3keeomCRgtimCx+L/K3HNo0QHTG1J7RzLVAchfQT0lu3pUJ8kB+UM6/6NG+fVyysJyRZ9gadsr4gvHHckw8oUBp2tHvqBEkEdY+rt1Mf5jppt7JUV7HAPLB/qR5jhALY2FX/8MN+lPLmb/nLQQichVQIDAQAB\r\n-----END PUBLIC KEY-----`;
+const PUBLIC_KEY_WRONG = `-----BEGIN PUBLIC KEY-----\r\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0lOqMuPLCVusc6szklNXQL1FHhSkEgR7An+8BllBqTsRHM4bRYosseGFCbYPn8r8FsWuMDtxp0CwTyMQR2PCbJ740DdpbE1KC6jAfZxqcBete7gP0tooJtbvnA6X4vNpG4ukhtUoN9DzNOO0eqMU0Rgyy5HjERdYEWkwTNB30i9I+nHFOSj4MGLBSxNlnuo3keeomCRgtimCx+L/K3HNo0QHTG1J7RzLVAchfQT0lu3pUJ8kB+UM6/6NG+fVyysJyRZ9gadsr4gvHHckw8oUBp2tHvqBEkEdY+rt1Mf5jppt7JUV7HAPLB/qR5jhALY2FX/8MN+lPLmb/nLQQichVQIDAQAC\r\n-----END PUBLIC KEY-----`;
 
 const validator = createValidator(PUBLIC_KEY);
+const badKeyValidator = createValidator(PUBLIC_KEY_WRONG);
+const noKeyValidator = createValidator('');
 
 describe('isRdpcMember', () => {
   it('should invalidate all non RDPC tokens', () => {
@@ -102,6 +105,29 @@ describe('isValidJwt', () => {
   });
   it('should return false for expired token', () => {
     expect(validator.isValidJwt(EXPIRED_TOKEN)).toBe(false);
+  });
+  it('should return false for the wrong public key', () => {
+    expect(badKeyValidator.isValidJwt(DCC_USER)).toBe(false);
+  });
+  it('should return false for no provided public key', () => {
+    expect(noKeyValidator.isValidJwt(DCC_USER)).toBe(false);
+  });
+});
+
+describe('decodeToken', () => {
+  it('should return data for a valid token', () => {
+    const decoded = validator.decodeToken(DCC_USER);
+    expect(decoded.context.user.name).toBe('oicrtestuser@gmail.com');
+    expect(decoded.context.scope.length).toBeGreaterThan(0);
+  });
+  it('should throw error for invalid token', () => {
+    expect(() => validator.decodeToken(EXPIRED_TOKEN)).toThrowError();
+  });
+  it('should throw error for valid token with wrong public key', () => {
+    expect(() => badKeyValidator.decodeToken(DCC_USER)).toThrowError();
+  });
+  it('should throw error for valid token with no public key', () => {
+    expect(() => noKeyValidator.decodeToken(DCC_USER)).toThrowError();
   });
 });
 


### PR DESCRIPTION
Verify is used in `decodeToken` and in `isValidJwt` methods.

Due to use in `decodeToken`, all checks that do inspection of jwt content require a valid JWT to pass. Also, decodeToken will throw an error (no content returned) if the jwt is invalid. If we need to decode an invalid token (to read expiry time or email or something) we will need a separate method (though that might not be a good thing to provide, up for discussion).

Refactored isDcc and isRdpc into an argoRoleChecks file.

Added tests for changes made to decodeToken and isValidJwt to handle good, bad, and empty token cases.