### PR TITLE
Provide validation for granting kafka topic write permissions

### DIFF
--- a/src/argoRoleChecks.ts
+++ b/src/argoRoleChecks.ts
@@ -40,7 +40,7 @@ export const isRdpcMember = (permissions: string[]): boolean => {
   try {
     const rdpcPermissions = permissions.filter(p => {
       const policy = p.split('.')[0];
-      return policy.indexOf(RDPC_PREFIX) === 0;
+      return policy.startsWith(RDPC_PREFIX);
     });
     const isMember =
       rdpcPermissions.some(p =>

--- a/src/argoRoleChecks.ts
+++ b/src/argoRoleChecks.ts
@@ -20,7 +20,7 @@
 
 import { PERMISSIONS } from './common';
 
-export const DCC_PREFIX = 'PROGRAMSERVICE.WRITE';
+export const DCC_ADMIN_PERMISSION = 'PROGRAMSERVICE.WRITE';
 export const RDPC_PREFIX = 'RDPC-';
 
 /**
@@ -28,7 +28,8 @@ export const RDPC_PREFIX = 'RDPC-';
  * @param egoJwt
  */
 export const isDccMember = (permissions: string[]): boolean => {
-  return permissions.some(p => p.includes(DCC_PREFIX));
+  const regex = new RegExp(`^${DCC_ADMIN_PERMISSION}$`);
+  return permissions.some(p => p.match(regex));
 };
 
 /**

--- a/src/argoRoleChecks.ts
+++ b/src/argoRoleChecks.ts
@@ -28,8 +28,7 @@ export const RDPC_PREFIX = 'RDPC-';
  * @param egoJwt
  */
 export const isDccMember = (permissions: string[]): boolean => {
-  const regex = new RegExp(`^${DCC_ADMIN_PERMISSION}$`);
-  return permissions.some(p => p.match(regex));
+  return permissions.includes(DCC_ADMIN_PERMISSION);
 };
 
 /**

--- a/src/common.ts
+++ b/src/common.ts
@@ -31,6 +31,7 @@ export const PERMISSIONS: {
 };
 export const PROGRAM_PREFIX = 'PROGRAM-';
 export const PROGRAM_DATA_PREFIX = 'PROGRAMDATA-';
+export const KAFKA_TOPIC_PREFIX = 'DCCKAFKA-';
 
 export enum UserStatus {
   APPROVED = 'APPROVED',

--- a/src/index.ts
+++ b/src/index.ts
@@ -243,9 +243,9 @@ const getProgramMembershipAccessLevel = (args: {
 };
 
 /**
- *
- * @param permissions
- * @param topic
+ * Validate that there exists the correct permission
+ * to allow writing to the Platform Kafka on the given topic.
+ * @param args
  * @returns
  */
 const canWriteKafkaTopic = (args: { permissions: string[]; topic: string }) =>
@@ -281,4 +281,12 @@ export default (egoPublicKey: string) => ({
   canWriteKafkaTopic: canWriteKafkaTopic,
 });
 
-export { PERMISSIONS, PermissionScopeObj, PROGRAM_DATA_PREFIX, PROGRAM_PREFIX } from './common';
+export {
+  PERMISSIONS,
+  PermissionScopeObj,
+  PROGRAM_DATA_PREFIX,
+  PROGRAM_PREFIX,
+  KAFKA_TOPIC_PREFIX,
+} from './common';
+
+export { RDPC_PREFIX, DCC_ADMIN_PERMISSION } from './argoRoleChecks';

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import {
   isPermission,
   PROGRAM_PREFIX,
   PROGRAM_DATA_PREFIX,
+  KAFKA_TOPIC_PREFIX,
   parseScope,
 } from './common';
 import {
@@ -241,6 +242,15 @@ const getProgramMembershipAccessLevel = (args: {
   }
 };
 
+/**
+ *
+ * @param permissions
+ * @param topic
+ * @returns
+ */
+const canWriteKafkaTopic = (args: { permissions: string[]; topic: string }) =>
+  args.permissions.includes(`${KAFKA_TOPIC_PREFIX}${args.topic}.${PERMISSIONS.WRITE}`);
+
 export default (egoPublicKey: string) => ({
   serializeScope: serializeScope,
   parseScope: parseScope,
@@ -268,6 +278,7 @@ export default (egoPublicKey: string) => ({
   getReadableProgramDataNames: getReadableProgramDataNames,
   getWritableProgramDataNames: getWritableProgramDataNames,
   getProgramMembershipAccessLevel: getProgramMembershipAccessLevel,
+  canWriteKafkaTopic: canWriteKafkaTopic,
 });
 
 export { PERMISSIONS, PermissionScopeObj, PROGRAM_DATA_PREFIX, PROGRAM_PREFIX } from './common';

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,8 +91,7 @@ const getPermissionsFromToken = (egoPublicKey: string) => (egoJwt: string): stri
 const getReadableProgramScopes = (permissions: string[]): PermissionScopeObj[] => {
   const programPermissions = permissions.filter(p => {
     const policy = p.split('.')[0];
-    const output =
-      policy.indexOf(PROGRAM_PREFIX) === 0 && policy.indexOf(PROGRAM_DATA_PREFIX) !== 0;
+    const output = policy.startsWith(PROGRAM_PREFIX) && policy.indexOf(PROGRAM_DATA_PREFIX) !== 0;
     return output;
   });
 
@@ -112,8 +111,7 @@ const getReadableProgramScopes = (permissions: string[]): PermissionScopeObj[] =
 const getWriteableProgramScopes = (permissions: string[]): PermissionScopeObj[] => {
   const programPermissions = permissions.filter(p => {
     const policy = p.split('.')[0];
-    const output =
-      policy.indexOf(PROGRAM_PREFIX) === 0 && policy.indexOf(PROGRAM_DATA_PREFIX) !== 0;
+    const output = policy.startsWith(PROGRAM_PREFIX) && policy.indexOf(PROGRAM_DATA_PREFIX) !== 0;
     return output;
   });
 

--- a/src/programDataUtils.ts
+++ b/src/programDataUtils.ts
@@ -25,7 +25,7 @@ import { isDccMember } from './argoRoleChecks';
 export const getReadableProgramDataScopes = (permissions: string[]): PermissionScopeObj[] => {
   const programDataPermissions = permissions.filter(p => {
     const policy = p.split('.')[0];
-    const output = policy.indexOf(PROGRAM_DATA_PREFIX) === 0;
+    const output = policy.startsWith(PROGRAM_DATA_PREFIX);
     return output;
   });
   return programDataPermissions
@@ -42,7 +42,7 @@ export const getReadableProgramDataNames = (permissions: string[]): string[] =>
 export const getWritableProgramDataScopes = (permissions: string[]): PermissionScopeObj[] => {
   const programDataPermissions = permissions.filter(p => {
     const policy = p.split('.')[0];
-    const output = policy.indexOf(PROGRAM_DATA_PREFIX) === 0;
+    const output = policy.startsWith(PROGRAM_DATA_PREFIX);
     return output;
   });
   return programDataPermissions

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -19,6 +19,7 @@
  */
 
 import createValidator from '../src';
+import { DCC_ADMIN_PERMISSION } from '../src/argoRoleChecks';
 
 /** has the following scopes:
  * "PROGRAMDATA-PACA-AU.WRITE"
@@ -231,6 +232,14 @@ describe('isDccMember', () => {
   });
   it('should return false if fail', () => {
     expect(validator.isDccMember(validator.getPermissionsFromToken('asdfsdf'))).toBe(false);
+  });
+  it('should return false given partial permission match', () => {
+    const partialPermissions = [
+      `extra${DCC_ADMIN_PERMISSION}`,
+      `${DCC_ADMIN_PERMISSION}extra`,
+      `extra${DCC_ADMIN_PERMISSION}stuff`,
+    ];
+    expect(validator.isDccMember(partialPermissions)).toBe(false);
   });
 });
 

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -484,3 +484,55 @@ describe('getProgramMembershipAccessLevel', () => {
     ).not.toBe('ASSOCIATE_PROGRAM_MEMBER');
   });
 });
+describe('canWriteKafkaTopic', () => {
+  it('should return true for a the valid scope', () => {
+    expect(
+      validator.canWriteKafkaTopic({
+        permissions: ['DCCKAFKA-test_topic.WRITE'],
+        topic: 'test_topic',
+      }),
+    ).toBe(true);
+  });
+  it('should return false for a matching topic with lesser (READ) scope', () => {
+    expect(
+      validator.canWriteKafkaTopic({
+        permissions: ['DCCKAFKA-test_topic.READ'],
+        topic: 'test_topic',
+      }),
+    ).toBe(false);
+  });
+  it('should return false for an incorrect topic', () => {
+    expect(
+      validator.canWriteKafkaTopic({
+        permissions: ['DCCKAFKA-wrong_topic.WRITE'],
+        topic: 'test_topic',
+      }),
+    ).toBe(false);
+  });
+  it('should return false for an partial and matches', () => {
+    expect(
+      validator.canWriteKafkaTopic({
+        permissions: [
+          'extraDCCKAFKA-test_topic.WRITE',
+          'DCCKAFKA-extratest_topic.WRITE',
+          'DCCKAFKA-test_topicextra.WRITE',
+          'DCCKAFKA-test_topic.extraWRITE',
+          'DCCKAFKA-test_topic.WRITEextra',
+          'DCCKAFKA-test_topic.WRITE.WRITE',
+          'DCCKAFKA-test_topic.WRITEextra',
+          'DCCKAFKA-test_topic-test_topic.WRITE',
+          'DCCKAFKA-test_to.WRITE',
+        ],
+        topic: 'test_topic',
+      }),
+    ).toBe(false);
+  });
+  it('should return false for an empty permissions array', () => {
+    expect(
+      validator.canWriteKafkaTopic({
+        permissions: [],
+        topic: 'test_topic',
+      }),
+    );
+  });
+});


### PR DESCRIPTION
As discussed [here](https://github.com/icgc-argo/platform-api/issues/346), we want to be able to validate requests based on the following permission pattern: `DCCKAFKA-<topic>.WRITE` . This implements a method to do just this.

Tests are updated.

Some existing implementations are simplified, all tests still pass.

The library now exports all constants used in its logic (RDPC-member prefix, and DCC-ADMIN scope)